### PR TITLE
Add error handling in the rusttype module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ appveyor = { repository = "manuel-rhdt/harfbuzz_rs", branch = "master", service 
 harfbuzz-sys = "^0.1"
 libc = "^0.2"
 rusttype = "^0.3"
-lazy_static = "~1"
+failure = "^0.1"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -23,7 +23,7 @@ fn main() {
     let path = "testfiles/SourceSansVariable-Roman.ttf";
     let face = Face::from_file(path, index).expect("Error reading font file.");
     let mut font = Font::new(face);
-    font.set_rusttype_funcs();
+    font.set_rusttype_funcs().expect("An error occured");
 
     // Create a buffer with some text, shape it...
     let result = UnicodeBuffer::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,37 +19,33 @@
 //! with some text and call the `shape` function.
 //!
 //! ```
+//! # extern crate harfbuzz_rs;
 //! use harfbuzz_rs::*;
 //! use harfbuzz_rs::rusttype::SetRustTypeFuncs;
+//!
+//! # extern crate failure;
+//! # use failure::Error;
+//! # fn try_main() -> Result<(), Error> {
 //!
 //! let path = "path/to/some/font_file.otf";
 //! let index = 0; //< face index in the font file
 //! # let path = "testfiles/SourceSansVariable-Roman.ttf";
-//! let face = Face::from_file(path, index).unwrap();
+//! let face = Face::from_file(path, index)?;
 //! let mut font = Font::new(face);
 //! // Use RustType as provider for font information that harfbuzz needs.
 //! // You can also use a custom font implementation. For more information look
 //! // at the documentation for `FontFuncs`.
-//! font.set_rusttype_funcs();
+//! font.set_rusttype_funcs()?;
 //!
 //! let output = UnicodeBuffer::new().add_str("Hello World!").shape(&font, &[]);
-//! ```
 //!
-//! The results of the shaping operation are stored in the buffer that was also used as input to
-//! the `shape` function.
+//! // The results of the shaping operation are stored in the `output` buffer.
 //!
-//! ```
-//! # use harfbuzz_rs::*;
-//! # use harfbuzz_rs::rusttype::SetRustTypeFuncs;
-//! #
-//! # let index = 0;
-//! # let path = "testfiles/SourceSansVariable-Roman.ttf";
-//! # let face = Face::from_file(path, index).unwrap();
-//! # let mut font = Font::new(face);
-//! # font.set_rusttype_funcs();
-//! # let output = UnicodeBuffer::new().add_str("Hello World!").shape(&font, &[]);
 //! let positions = output.get_glyph_positions();
 //! let infos = output.get_glyph_infos();
+//!
+//! # assert_eq!(positions.len(), 12);
+//! assert_eq!(positions.len(), infos.len());
 //!
 //! // iterate over the shaped glyphs
 //! for (position, info) in positions.iter().zip(infos) {
@@ -62,6 +58,13 @@
 //!     // Here you would usually draw the glyphs.
 //!     println!("gid{:?}={:?}@{:?},{:?}+{:?}", gid, cluster, x_advance, x_offset, y_offset);
 //! }
+//!
+//! # Ok(())
+//! # }
+//! #
+//! # fn main() {
+//! #   try_main().unwrap();
+//! # }
 //! ```
 //! This should print out something similar to the following:
 //!
@@ -81,6 +84,8 @@
 //! ```
 #![deny(missing_debug_implementations)]
 
+#[macro_use]
+extern crate failure;
 extern crate harfbuzz_sys as hb;
 extern crate libc;
 


### PR DESCRIPTION
I decided to use the failure crate as it should provide the default
error handling system for rust. This change is a breaking change and
will land in the 0.2 version of this crate (which will be released
rather soonish).

Closes #5 