### PR TITLE
Improve the interface for hb_buffer_t

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,39 +2,36 @@ use hb;
 use std;
 
 use font::Font;
-use common::{HarfbuzzObject, Language, Tag};
+use common::{HarfbuzzObject, HbBox, Language, Tag};
 
 pub type GlyphPosition = hb::hb_glyph_position_t;
 pub type GlyphInfo = hb::hb_glyph_info_t;
 pub type Feature = hb::hb_feature_t;
 
-struct BufferRaw {
-    hb_buffer: *mut hb::hb_buffer_t,
+
+#[derive(Debug)]
+pub(crate) struct GenericBuffer {
+    _raw: hb::hb_buffer_t,
 }
-impl BufferRaw {
-    fn new() -> BufferRaw {
+impl GenericBuffer {
+    pub(crate) fn new() -> HbBox<GenericBuffer> {
         let buffer = unsafe { hb::hb_buffer_create() };
-
-        BufferRaw { hb_buffer: buffer }
+        unsafe { HbBox::from_raw(buffer) }
     }
 
-    fn as_raw(&self) -> *mut hb::hb_buffer_t {
-        self.hb_buffer
+    pub(crate) fn len(&self) -> usize {
+        unsafe { hb::hb_buffer_get_length(self.as_raw()) as usize }
     }
 
-    fn len(&self) -> usize {
-        unsafe { hb::hb_buffer_get_length(self.hb_buffer) as usize }
-    }
-
-    fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    fn add_str(&mut self, string: &str) {
+    pub(crate) fn add_str(&mut self, string: &str) {
         let utf8_ptr = string.as_ptr() as *const i8;
         unsafe {
             hb::hb_buffer_add_utf8(
-                self.hb_buffer,
+                self.as_raw(),
                 utf8_ptr,
                 string.len() as i32,
                 0,
@@ -43,21 +40,21 @@ impl BufferRaw {
         }
     }
 
-    fn set_direction(&mut self, direction: hb::hb_direction_t) {
-        unsafe { hb::hb_buffer_set_direction(self.hb_buffer, direction) };
+    pub(crate) fn set_direction(&mut self, direction: hb::hb_direction_t) {
+        unsafe { hb::hb_buffer_set_direction(self.as_raw(), direction) };
     }
 
     /// Returns the `Buffer`'s text direction.
-    fn get_direction(&self) -> hb::hb_direction_t {
-        unsafe { hb::hb_buffer_get_direction(self.hb_buffer) }
+    pub(crate) fn get_direction(&self) -> hb::hb_direction_t {
+        unsafe { hb::hb_buffer_get_direction(self.as_raw()) }
     }
 
-    fn set_language(&mut self, lang: Language) {
-        unsafe { hb::hb_buffer_set_language(self.hb_buffer, lang.0) }
+    pub(crate) fn set_language(&mut self, lang: Language) {
+        unsafe { hb::hb_buffer_set_language(self.as_raw(), lang.0) }
     }
 
-    fn get_language(&self) -> Option<Language> {
-        let raw_lang = unsafe { hb::hb_buffer_get_language(self.hb_buffer) };
+    pub(crate) fn get_language(&self) -> Option<Language> {
+        let raw_lang = unsafe { hb::hb_buffer_get_language(self.as_raw()) };
         if raw_lang.is_null() {
             None
         } else {
@@ -65,109 +62,149 @@ impl BufferRaw {
         }
     }
 
-    fn set_script(&mut self, script: hb::hb_script_t) {
-        unsafe { hb::hb_buffer_set_script(self.hb_buffer, script) }
+    pub(crate) fn set_script(&mut self, script: hb::hb_script_t) {
+        unsafe { hb::hb_buffer_set_script(self.as_raw(), script) }
     }
 
-    fn get_script(&self) -> hb::hb_script_t {
-        unsafe { hb::hb_buffer_get_script(self.hb_buffer) }
+    pub(crate) fn get_script(&self) -> hb::hb_script_t {
+        unsafe { hb::hb_buffer_get_script(self.as_raw()) }
     }
 
-    fn guess_segment_properties(&mut self) {
-        unsafe { hb::hb_buffer_guess_segment_properties(self.hb_buffer) };
+    pub(crate) fn guess_segment_properties(&mut self) {
+        unsafe { hb::hb_buffer_guess_segment_properties(self.as_raw()) };
     }
 
-    fn get_segment_properties(&self) -> hb::hb_segment_properties_t {
+    pub(crate) fn get_segment_properties(&self) -> hb::hb_segment_properties_t {
         unsafe {
             let mut segment_props: hb::hb_segment_properties_t = std::mem::uninitialized();
-            hb::hb_buffer_get_segment_properties(self.hb_buffer, &mut segment_props as *mut _);
+            hb::hb_buffer_get_segment_properties(self.as_raw(), &mut segment_props as *mut _);
             segment_props
         }
     }
 
-    fn shape(&mut self, font: &Font, features: &[Feature]) {
+    pub(crate) fn shape(&mut self, font: &Font, features: &[Feature]) {
         unsafe {
             hb::hb_shape(
                 font.as_raw(),
-                self.hb_buffer,
+                self.as_raw(),
                 features.as_ptr(),
                 features.len() as u32,
             )
         };
     }
 
-    fn clear_contents(&mut self) {
-        unsafe { hb::hb_buffer_clear_contents(self.hb_buffer) };
+    pub(crate) fn clear_contents(&mut self) {
+        unsafe { hb::hb_buffer_clear_contents(self.as_raw()) };
     }
 
-    fn get_glyph_positions(&self) -> &[GlyphPosition] {
+    pub(crate) fn get_glyph_positions(&self) -> &[GlyphPosition] {
         unsafe {
             let mut length: u32 = 0;
             let glyph_pos =
-                hb::hb_buffer_get_glyph_positions(self.hb_buffer, &mut length as *mut u32);
+                hb::hb_buffer_get_glyph_positions(self.as_raw(), &mut length as *mut u32);
             std::slice::from_raw_parts(glyph_pos, length as usize)
         }
     }
 
-    fn get_glyph_infos(&self) -> &[GlyphInfo] {
+    pub(crate) fn get_glyph_infos(&self) -> &[GlyphInfo] {
         unsafe {
             let mut length: u32 = 0;
             let glyph_infos =
-                hb::hb_buffer_get_glyph_infos(self.hb_buffer, &mut length as *mut u32);
+                hb::hb_buffer_get_glyph_infos(self.as_raw(), &mut length as *mut u32);
             std::slice::from_raw_parts(glyph_infos, length as usize)
         }
     }
 
     /// Reverse the `Buffer`'s contents.
-    fn reverse(&mut self) {
-        unsafe { hb::hb_buffer_reverse(self.hb_buffer) };
+    pub(crate) fn reverse(&mut self) {
+        unsafe { hb::hb_buffer_reverse(self.as_raw()) };
     }
 
     /// Reverse the `Buffer`'s contents in the range from `start` to `end`.
-    fn reverse_range(&mut self, start: usize, end: usize) {
+    pub(crate) fn reverse_range(&mut self, start: usize, end: usize) {
         assert!(start <= self.len(), end <= self.len());
-        unsafe { hb::hb_buffer_reverse_range(self.hb_buffer, start as u32, end as u32) }
+        unsafe { hb::hb_buffer_reverse_range(self.as_raw(), start as u32, end as u32) }
+    }
+
+    pub(crate) fn content_type(&self) -> hb::hb_buffer_content_type_t {
+        unsafe { hb::hb_buffer_get_content_type(self.as_raw()) }
     }
 }
 
-impl Clone for BufferRaw {
-    fn clone(&self) -> Self {
-        unsafe {
-            hb::hb_buffer_reference(self.hb_buffer);
-        }
-        BufferRaw {
-            hb_buffer: self.hb_buffer,
-        }
+impl HarfbuzzObject for GenericBuffer {
+    type Raw = hb::hb_buffer_t;
+
+    unsafe fn reference(&self) {
+        hb::hb_buffer_reference(self.as_raw());
+    }
+
+    unsafe fn dereference(&self) {
+        hb::hb_buffer_destroy(self.as_raw());
     }
 }
 
-impl Drop for BufferRaw {
-    fn drop(&mut self) {
-        unsafe {
-            hb::hb_buffer_destroy(self.hb_buffer);
+/// This type provides an interface to create one of the buffer types from a raw harfbuzz pointer.
+#[derive(Debug)]
+pub enum TypedBuffer {
+    Unicode(UnicodeBuffer),
+    Glyphs(GlyphBuffer),
+}
+
+impl TypedBuffer {
+    pub unsafe fn take_from_raw(raw: *mut hb::hb_buffer_t) -> Option<TypedBuffer> {
+        let generic_buf: HbBox<GenericBuffer> = HbBox::from_raw(raw);
+        let content_type = generic_buf.content_type();
+        match content_type {
+            hb::HB_BUFFER_CONTENT_TYPE_UNICODE => Some(TypedBuffer::Unicode(UnicodeBuffer(generic_buf))),
+            hb::HB_BUFFER_CONTENT_TYPE_GLYPHS => Some(TypedBuffer::Glyphs(GlyphBuffer(generic_buf))),
+            _ => None,
         }
     }
 }
 
 /// A `UnicodeBuffer` can be filled with unicode text and corresponding cluster indices.
-#[derive(Clone)]
-pub struct UnicodeBuffer(BufferRaw);
-#[allow(dead_code)]
+/// 
+/// The buffer manages an allocation for the unicode codepoints to be shaped. This allocation however
+/// is reused for storing the results of the shaping operation in a `GlyphBuffer` object. 
+/// 
+/// If you want to get a `UnicodeBuffer` from a pointer to a raw harfbuzz object, you need to use the
+/// `from_raw` static method on `TypedBuffer`. This ensures that a buffer of correct type is created.
+pub struct UnicodeBuffer(HbBox<GenericBuffer>);
 impl UnicodeBuffer {
     /// Creates a new empty `Buffer`.
+    ///
+    /// # Examples
+    /// ```
+    /// use harfbuzz_rs::UnicodeBuffer;
+    ///
+    /// let buffer = UnicodeBuffer::new();
+    /// assert!(buffer.is_empty());
+    /// ```
     pub fn new() -> UnicodeBuffer {
-        UnicodeBuffer(BufferRaw::new())
+        UnicodeBuffer(GenericBuffer::new())
     }
 
-    /// Returns a pointer to the underlying raw harfbuzz buffer.
-    pub fn as_raw(&self) -> *mut hb::hb_buffer_t {
-        self.0.as_raw()
+    /// Converts this buffer to a raw harfbuzz object pointer.
+    pub fn into_raw(self) -> *mut hb::hb_buffer_t {
+        HbBox::into_raw(self.0)
     }
 
     /// Returns the length of the data of the buffer.
     ///
-    /// When called before shaping this is the number of unicode codepoints contained in the
-    /// buffer. When called after shaping it returns the number of glyphs stored.
+    /// This corresponds to the number of unicode codepoints contained in the buffer.
+    ///
+    /// # Examples
+    /// ```
+    /// use harfbuzz_rs::UnicodeBuffer;
+    ///
+    /// let str1 = "Hello ";
+    /// let buffer = UnicodeBuffer::new().add_str(str1);
+    /// assert_eq!(buffer.len(), str1.len());
+    ///
+    /// let str2 = "😍🙈";
+    /// let buffer = buffer.add_str(str2);
+    /// assert_eq!(buffer.len(), str1.len() + 2);;
+    /// ```
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -177,21 +214,50 @@ impl UnicodeBuffer {
         self.0.is_empty()
     }
 
-    /// Adds the string slice to the `Buffer`'s array of codepoints.
-    pub fn add_str(mut self, string: &str) -> UnicodeBuffer {
-        self.0.add_str(string);
+    /// Add the string slice `str_slice` to the `Buffer`'s array of codepoints.
+    ///
+    /// # Examples
+    /// ```
+    /// use harfbuzz_rs::UnicodeBuffer;
+    ///
+    /// let buffer = UnicodeBuffer::new().add_str("Hello");
+    /// let buffer = buffer.add_str(" World");
+    /// assert_eq!(buffer.string_lossy(), "Hello World");
+    /// ```
+    pub fn add_str(mut self, str_slice: &str) -> UnicodeBuffer {
+        self.0.add_str(str_slice);
         self
     }
 
-    fn get_string(&self) -> String {
-        self.0
-            .get_glyph_infos()
-            .iter()
-            .map(|info| std::char::from_u32(info.codepoint).unwrap())
+    /// Returns an Iterator over the stored unicode codepoints.
+    ///
+    /// # Examples
+    /// ```
+    /// use harfbuzz_rs::UnicodeBuffer;
+    ///
+    /// let buffer = UnicodeBuffer::new().add_str("ab");
+    /// let mut iterator = buffer.codepoints();
+    ///
+    /// assert_eq!('a' as u32, iterator.next().unwrap());
+    /// assert_eq!('b' as u32, iterator.next().unwrap());
+    /// assert!(iterator.next().is_none());
+    /// ```
+    pub fn codepoints<'a>(&'a self) -> CodepointsIter<'a> {
+        CodepointsIter {
+            slice_iter: self.0.get_glyph_infos().iter(),
+        }
+    }
+
+    /// Get the stored codepoints as a `String`.
+    ///
+    /// Invalid codepoints get replaced by the U+FFFD replacement character.
+    pub fn string_lossy(&self) -> String {
+        self.codepoints()
+            .map(|cp| std::char::from_u32(cp).unwrap_or('\u{FFFD}'))
             .collect()
     }
 
-    /// Sets the text direction of the `Buffer`'s contents.
+    /// Set the text direction of the `Buffer`'s contents.
     pub fn set_direction(mut self, direction: hb::hb_direction_t) -> UnicodeBuffer {
         self.0.set_direction(direction);
         self
@@ -202,40 +268,63 @@ impl UnicodeBuffer {
         self.0.get_direction()
     }
 
+    /// Set the script from an ISO15924 tag.
     pub fn set_script(mut self, script: Tag) -> UnicodeBuffer {
         self.0
             .set_script(unsafe { hb::hb_script_from_iso15924_tag(script.0) });
         self
     }
 
+    /// Get the ISO15924 script tag.
     pub fn get_script(&self) -> Tag {
         Tag(unsafe { hb::hb_script_to_iso15924_tag(self.0.get_script()) })
     }
 
+    /// Set the buffer language.
     pub fn set_language(mut self, lang: Language) -> UnicodeBuffer {
         self.0.set_language(lang);
         self
     }
 
+    /// Get the buffer language.
     pub fn get_language(&self) -> Option<Language> {
         self.0.get_language()
     }
 
+    /// Guess the segment properties (direction, language, script) for the current buffer.
     pub fn guess_segment_properties(mut self) -> UnicodeBuffer {
         self.0.guess_segment_properties();
         self
     }
 
+    /// Get the segment properties (direction, language, script) of the current buffer.
     pub fn get_segment_properties(&self) -> hb::hb_segment_properties_t {
         self.0.get_segment_properties()
     }
 
+    /// Shape the contents of the buffer using the provided font and activating all OpenType features
+    /// given in `features`.
+    ///
+    /// This function consumes the `UnicodeBuffer` and returns a `GlyphBuffer` containing the
+    /// resulting glyph indices and the corresponding positioning information.
     pub fn shape(mut self, font: &Font, features: &[Feature]) -> GlyphBuffer {
         self = self.guess_segment_properties();
         self.0.shape(font, features);
         GlyphBuffer(self.0)
     }
 
+    /// Clear the contents of the buffer (i.e. the stored string of unicode characters).
+    ///
+    /// # Examples
+    /// ```
+    /// use harfbuzz_rs::UnicodeBuffer;
+    ///
+    /// let buffer = UnicodeBuffer::new();
+    /// let buffer = buffer.add_str("Test!");
+    /// assert_eq!(buffer.len(), 5);
+    /// let buffer = buffer.clear_contents();
+    /// assert!(buffer.is_empty());
+    /// ```
     pub fn clear_contents(mut self) -> UnicodeBuffer {
         self.0.clear_contents();
         self
@@ -244,8 +333,8 @@ impl UnicodeBuffer {
 
 impl std::fmt::Debug for UnicodeBuffer {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct("Buffer")
-            .field("content", &self.get_string())
+        fmt.debug_struct("UnicodeBuffer")
+            .field("content", &self.string_lossy())
             .field("direction", &self.get_direction())
             .field("language", &self.get_language())
             .field("script", &self.get_script())
@@ -259,10 +348,26 @@ impl std::default::Default for UnicodeBuffer {
     }
 }
 
-/// A `GlyphBuffer` is obtained through the `shape` function of a `UnicodeBuffer`. It contains
-/// the resulting output information of the shaping process.
-#[derive(Clone)]
-pub struct GlyphBuffer(BufferRaw);
+/// An iterator over the codepoints stored in a `UnicodeBuffer`.
+///
+/// You get an iterator of this type from the `codepoints()` method on `UnicodeBuffer`.
+#[derive(Debug)]
+pub struct CodepointsIter<'a> {
+    slice_iter: std::slice::Iter<'a, GlyphInfo>,
+}
+
+impl<'a> Iterator for CodepointsIter<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        self.slice_iter.next().map(|info| info.codepoint)
+    }
+}
+
+/// A `GlyphBuffer` contains the resulting output information of the shaping process. 
+/// 
+/// An object of this type is obtained through the `shape` function of a `UnicodeBuffer`.
+pub struct GlyphBuffer(HbBox<GenericBuffer>);
 
 impl GlyphBuffer {
     /// Returns the length of the data of the buffer.
@@ -273,9 +378,9 @@ impl GlyphBuffer {
         self.0.len()
     }
 
-    /// Returns a pointer to the underlying raw harfbuzz buffer.
-    pub fn as_raw(&self) -> *mut hb::hb_buffer_t {
-        self.0.as_raw()
+    /// Converts this buffer to a raw harfbuzz object pointer.
+    pub fn into_raw(self) -> *mut hb::hb_buffer_t {
+        HbBox::into_raw(self.0)
     }
 
     /// Returns `true` if the buffer contains no elements.
@@ -283,10 +388,12 @@ impl GlyphBuffer {
         self.0.is_empty()
     }
 
+    /// Get the glyph positions.
     pub fn get_glyph_positions(&self) -> &[GlyphPosition] {
         self.0.get_glyph_positions()
     }
 
+    /// Get the glyph infos.
     pub fn get_glyph_infos(&self) -> &[GlyphInfo] {
         self.0.get_glyph_infos()
     }
@@ -311,15 +418,9 @@ impl GlyphBuffer {
 
 impl std::fmt::Debug for GlyphBuffer {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct("Buffer")
-            .field("glyph positions", &self.get_glyph_positions())
-            .field("glyph infos", &self.get_glyph_infos())
+        fmt.debug_struct("GlyphBuffer")
+            .field("glyph_positions", &self.get_glyph_positions())
+            .field("glyph_infos", &self.get_glyph_infos())
             .finish()
     }
-}
-
-#[derive(Debug, Clone)]
-pub enum Buffer {
-    UnicodeBuffer(UnicodeBuffer),
-    GlyphBuffer(GlyphBuffer),
 }


### PR DESCRIPTION
Internal reorganization:
------------------------
- Rename private BufferRaw to GenericBuffer (which for the moment
  remains private)
- GenericBuffer directly wraps hb_buffer_t and implements
  HarfbuzzObject.
- UnicodeBuffer and GlyphBuffer are now tuple structs containing a
  HbBox<GenericBuffer>. This makes the semantics of the types clear.
  Also all reference management is now handled by the HarfbuzzObject
  trait and the HbBox type and was removed from BufferRaw.

API changes:
------------
- UnicodeBuffer and GlyphBuffer no longer implement Clone (as they are
  mutable).
- A new enum called TypedBuffer is introduced which can only be created
  from a raw hb_buffer_t pointer. It contains either a UnicodeBuffer
  or a GlyphBuffer. This makes reusing hb_buffer_t objects from foreign
  code possible.
- UnicodeBuffer features new methods to get the inner unicode codepoints
  either as an iterator or a String.

Also some documentation was added.