### PR TITLE
Make shape a free-standing function

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 extern crate harfbuzz_rs;
 
-use harfbuzz_rs::{Face, Font, UnicodeBuffer};
+use harfbuzz_rs::{shape, Face, Font, UnicodeBuffer};
 use harfbuzz_rs::rusttype::SetRustTypeFuncs;
 
 // Execute this file from the root directory of this repository.
@@ -26,9 +26,9 @@ fn main() {
     font.set_rusttype_funcs().expect("An error occured");
 
     // Create a buffer with some text, shape it...
-    let result = UnicodeBuffer::new()
-        .add_str("Hello World!")
-        .shape(&font, &[]);
+    let buffer = UnicodeBuffer::new().add_str("Hello World!");
+    
+    let result = shape(&font, buffer, &[]);
 
     // ... and get the results.
     let positions = result.get_glyph_positions();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,9 @@
 //! // at the documentation for `FontFuncs`.
 //! font.set_rusttype_funcs()?;
 //!
-//! let output = UnicodeBuffer::new().add_str("Hello World!").shape(&font, &[]);
-//!
+//! let buffer = UnicodeBuffer::new().add_str("Hello World!");
+//! let output = shape(&font, buffer, &[]);
+//! 
 //! // The results of the shaping operation are stored in the `output` buffer.
 //!
 //! let positions = output.get_glyph_positions();
@@ -102,6 +103,24 @@ pub use face::*;
 pub use blob::*;
 pub use buffer::*;
 pub use common::*;
+
+/// Shape the contents of the buffer using the provided font and activating all OpenType features
+/// given in `features`.
+///
+/// This function consumes the `buffer` and returns a `GlyphBuffer` containing the
+/// resulting glyph indices and the corresponding positioning information.
+pub fn shape(font: &Font, buffer: UnicodeBuffer, features: &[Feature]) -> GlyphBuffer {
+    let buffer = buffer.guess_segment_properties();
+    unsafe {
+        hb::hb_shape(
+            font.as_raw(),
+            buffer.0.as_raw(),
+            features.as_ptr(),
+            features.len() as u32,
+        )
+    };
+    GlyphBuffer(buffer.0)
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is done for various reasons:
- It is the central function of harfbuzz and thus should stand out.
- It mirrors more closely the design of the C API.
- It is not clear that you call a buffer to shape itself with a font. It
  is equally valid to think of a font perform shaping of a buffer. Thus
  one of these types should not be emphasized over the other.