### PR TITLE
Update to rusttype 0.5. Use rusttype::Error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ appveyor = { repository = "manuel-rhdt/harfbuzz_rs", branch = "master", service 
 [dependencies]
 harfbuzz-sys = "^0.1"
 libc = "^0.2"
-rusttype = "^0.3"
-failure = "^0.1"
+rusttype = "^0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,7 @@
 //! use harfbuzz_rs::*;
 //! use harfbuzz_rs::rusttype::SetRustTypeFuncs;
 //!
-//! # extern crate failure;
-//! # use failure::Error;
-//! # fn try_main() -> Result<(), Error> {
+//! # fn try_main() -> Result<(), std::io::Error> {
 //!
 //! let path = "path/to/some/font_file.otf";
 //! let index = 0; //< face index in the font file
@@ -84,8 +82,6 @@
 //! ```
 #![deny(missing_debug_implementations)]
 
-#[macro_use]
-extern crate failure;
 extern crate harfbuzz_sys as hb;
 extern crate libc;
 

--- a/src/rusttype.rs
+++ b/src/rusttype.rs
@@ -5,6 +5,7 @@ extern crate rusttype;
 use common::Tag;
 use self::rusttype::{Codepoint, GlyphId, Scale};
 use self::rusttype::Font as RTFont;
+pub use self::rusttype::Error;
 
 use font;
 use face;
@@ -14,25 +15,12 @@ use std;
 use std::str::FromStr;
 use std::fmt::Debug;
 
-/// An error type generated when a failure occurs in a call to `set_rusttype_funcs`.
-#[derive(Debug, Fail)]
-pub enum RusttypeFontFuncsError {
-    /// This case indicates that for some reason Rusttype was not able to read the
-    /// font.
-    #[fail(display = "rusttype: Could not read font.")]
-    FontReadError,
-    /// This indicates that the font is malformed and does not contain all required
-    /// font tables.
-    #[fail(display = "Could not find table with tag `{}`.", _0)]
-    MissingTable(Tag),
-}
-
 // Work around weird rusttype scaling by reading the hhea table.
-fn get_font_height(font: &font::Font) -> Result<i32, RusttypeFontFuncsError> {
+fn get_font_height(font: &font::Font) -> Result<i32, Error> {
     let face = font.face();
     let tag = Tag::from_str("hhea").unwrap();
     let hhea_table = face.table_with_tag(tag)
-        .ok_or(RusttypeFontFuncsError::MissingTable(tag))?;
+        .ok_or(Error::IllFormed)?;
     if hhea_table.len() >= 8 {
         unsafe {
             let ascent_ptr = (&hhea_table)[4..6].as_ptr() as *const i16;
@@ -42,22 +30,20 @@ fn get_font_height(font: &font::Font) -> Result<i32, RusttypeFontFuncsError> {
             Ok(ascent as i32 - descent as i32)
         }
     } else {
-        Err(RusttypeFontFuncsError::MissingTable(tag))
+        Err(Error::IllFormed)
     }
 }
 
 fn rusttype_font_from_face<'a>(
     face: &face::Face<'a>,
-) -> Result<RTFont<'a>, RusttypeFontFuncsError> {
+) -> Result<RTFont<'a>, Error> {
     let font_blob = face.face_data();
     let index = face.index();
-    let collection = rusttype::FontCollection::from_bytes(font_blob);
-    collection
-        .font_at(index as usize)
-        .ok_or(RusttypeFontFuncsError::FontReadError)
+    let collection = rusttype::FontCollection::from_bytes(font_blob)?;
+    collection.font_at(index as usize)
 }
 
-fn rusttype_scale_from_hb_font(font: &font::Font) -> Result<Scale, RusttypeFontFuncsError> {
+fn rusttype_scale_from_hb_font(font: &font::Font) -> Result<Scale, Error> {
     let font_height = get_font_height(font)? as f32;
     let em_scale = font.scale();
     let x_scale = em_scale.0 as f32;
@@ -84,7 +70,7 @@ impl<'a> Debug for ScaledRusttypeFont<'a> {
 impl<'a> ScaledRusttypeFont<'a> {
     fn from_hb_font<'b>(
         hb_font: &font::Font<'b>,
-    ) -> Result<ScaledRusttypeFont<'b>, RusttypeFontFuncsError> {
+    ) -> Result<ScaledRusttypeFont<'b>, Error> {
         let font = rusttype_font_from_face(&hb_font.face())?;
         let scale = rusttype_scale_from_hb_font(hb_font)?;
         Ok(ScaledRusttypeFont {
@@ -97,12 +83,8 @@ impl<'a> ScaledRusttypeFont<'a> {
 impl<'a> FontFuncs for ScaledRusttypeFont<'a> {
     fn get_glyph_h_advance(&self, _: &Font, glyph: GlyphIndex) -> Position {
         let glyph = self.font.glyph(GlyphId(glyph));
-        if let Some(glyph) = glyph {
-            let glyph = glyph.scaled(self.scale);
-            glyph.h_metrics().advance_width.round() as Position
-        } else {
-            0
-        }
+        let glyph = glyph.scaled(self.scale);
+        glyph.h_metrics().advance_width.round() as Position
     }
 
     fn get_glyph_h_kerning(&self, _: &Font, left: GlyphIndex, right: GlyphIndex) -> Position {
@@ -113,21 +95,18 @@ impl<'a> FontFuncs for ScaledRusttypeFont<'a> {
 
     fn get_glyph_extents(&self, _: &Font, glyph: GlyphIndex) -> Option<GlyphExtents> {
         let glyph = self.font.glyph(GlyphId(glyph));
-        glyph.and_then(|glyph| {
-            let glyph = glyph.scaled(self.scale);
-            glyph.exact_bounding_box().map(|bbox| GlyphExtents {
-                x_bearing: bbox.min.x.round() as i32,
-                y_bearing: bbox.min.y.round() as i32,
-                width: (bbox.max.x - bbox.min.x).round() as i32,
-                height: (bbox.max.y - bbox.min.y).round() as i32,
-            })
+        let glyph = glyph.scaled(self.scale);
+        glyph.exact_bounding_box().map(|bbox| GlyphExtents {
+            x_bearing: bbox.min.x.round() as i32,
+            y_bearing: bbox.min.y.round() as i32,
+            width: (bbox.max.x - bbox.min.x).round() as i32,
+            height: (bbox.max.y - bbox.min.y).round() as i32,
         })
     }
 
     fn get_nominal_glyph(&self, _: &font::Font, unicode: char) -> Option<GlyphIndex> {
-        self.font
-            .glyph(Codepoint(unicode as u32))
-            .map(|glyph| glyph.id().0)
+        let glyph = self.font.glyph(Codepoint(unicode as u32));
+        Some(glyph.id().0)
     }
 }
 
@@ -135,11 +114,11 @@ impl<'a> FontFuncs for ScaledRusttypeFont<'a> {
 pub trait SetRustTypeFuncs {
     /// Let a font use rusttype's font API for getting information like the advance width of some
     /// glyph or its extents.
-    fn set_rusttype_funcs(&mut self) -> Result<(), RusttypeFontFuncsError>;
+    fn set_rusttype_funcs(&mut self) -> Result<(), Error>;
 }
 
 impl<'a> SetRustTypeFuncs for Font<'a> {
-    fn set_rusttype_funcs(&mut self) -> Result<(), RusttypeFontFuncsError> {
+    fn set_rusttype_funcs(&mut self) -> Result<(), Error> {
         let font_data = ScaledRusttypeFont::from_hb_font(self)?;
         self.set_font_funcs(font_data);
         Ok(())


### PR DESCRIPTION
In 0.5.0, the rusttype crate got its own `Error` type, which covers the same cases harfbuzz_rs's `RusttypeFontFuncsError` does. Rather than translate `rusttype::Error` values into `RusttypeFontFuncsError` values, I took the more intrusive approach of removing `RusttypeFontFuncsError`, and just re-exporting `rusttype::Error` as `harfbuzz_rs::rusttype::Error`. This removes the need to depend on the `failure` crate.

If you'd rather handle the update by keeping the `RusttypeFontFuncsError` type and translating `rusttype::Error` values into those, I'm happy to re-do the changes that way; just let me know.