### PR TITLE
Added from_bytes function for Face

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -26,7 +26,7 @@ pub struct Blob<'a> {
 }
 impl<'a> Blob<'a> {
     /// Create a new `Blob` from the slice `bytes`. The blob will not own the data.
-    pub fn with_bytes(bytes: &[u8]) -> Owned<Blob> {
+    pub fn with_bytes(bytes: &'a [u8]) -> Owned<Blob<'a>> {
         let hb_blob = unsafe {
             hb::hb_blob_create(
                 bytes.as_ptr() as *const i8,

--- a/src/face.rs
+++ b/src/face.rs
@@ -3,6 +3,8 @@ use hb;
 use libc::c_void;
 
 use std::marker::PhantomData;
+use std::path::Path;
+use std::io;
 
 use blob::Blob;
 use common::{HarfbuzzObject, Owned, Shared, Tag};
@@ -13,8 +15,6 @@ pub struct Face<'a> {
     hb_face: hb::hb_face_t,
     _marker: PhantomData<&'a [u8]>,
 }
-
-use std::path::Path;
 
 impl<'a> Face<'a> {
     /// Create a new `Face` from the data in `bytes`.
@@ -28,6 +28,11 @@ impl<'a> Face<'a> {
     pub fn from_file<P: AsRef<Path>>(path: P, index: u32) -> std::io::Result<Owned<Face<'static>>> {
         let blob = Blob::from_file(path)?;
         Ok(Face::new(blob, index))
+    }
+
+    pub fn from_bytes<'b>(bytes: &'b [u8], index: u32) -> Owned<Face<'b>> {
+        let blob = Blob::with_bytes(bytes);
+        Face::new(blob, index)
     }
 
     /// Create a new face from a closure that returns a raw [`Blob`](struct.Blob.html) of table


### PR DESCRIPTION
If I want to intialize a font from data that I've already loaded into memory, then I need some sort of function to load that data. Ideally, this function would be generic over all `R: Read` types.

Also added lifetimes for the `with_bytes` function - otherwise it would be possible that the bytes get destructed while an internal (unsafe) pointer is still pointing at them.