### PR TITLE
Create a `hb_feature_t` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Here you can look at what features are coming in the next version.
 
+### Added
+
+- `Face::empty` constructor as a simple way to construct the empty face
+- `Feature` struct that wraps `hb_feature_t` and has an easy to use constructor.
+
 ### Changed
 
 - removed kerning callbacks from FontFuncs (following the upstream harfbuzz
   change)
 - updated to use Rust 2018
+- Further improved docs
 
 ## [0.3.0] 2019-01-08
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::io;
 use std::io::Read;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct SegmentProperties {
     pub direction: Direction,
@@ -59,6 +59,23 @@ pub struct GlyphPosition {
     /// not affect how much the line advances.
     pub y_offset: Position,
     var: hb::hb_var_int_t,
+}
+
+impl GlyphPosition {
+    pub const fn new(
+        x_advance: Position,
+        y_advance: Position,
+        x_offset: Position,
+        y_offset: Position,
+    ) -> Self {
+        GlyphPosition {
+            x_advance,
+            y_advance,
+            x_offset,
+            y_offset,
+            var: hb::hb_var_int_t { u32: 0 },
+        }
+    }
 }
 
 /// A set of flags that may be set during shaping on each glyph.

--- a/src/common.rs
+++ b/src/common.rs
@@ -156,7 +156,7 @@ impl Direction {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Language(pub hb::hb_language_t);
 
 impl Default for Language {
@@ -203,7 +203,7 @@ impl FromStr for Language {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Script(pub hb::hb_script_t);
 
 impl Script {

--- a/src/common.rs
+++ b/src/common.rs
@@ -156,6 +156,7 @@ impl Direction {
     }
 }
 
+#[derive(Copy, Clone)]
 pub struct Language(pub hb::hb_language_t);
 
 impl Default for Language {
@@ -199,6 +200,23 @@ impl FromStr for Language {
         } else {
             Ok(Language(lang))
         }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Script(pub hb::hb_script_t);
+
+impl Script {
+    pub fn from_iso15924_tag(tag: Tag) -> Self {
+        Script(unsafe { hb::hb_script_from_iso15924_tag(tag.0) })
+    }
+
+    pub fn to_iso15924_tag(self) -> Tag {
+        Tag(unsafe { hb::hb_script_to_iso15924_tag(self.0) })
+    }
+
+    pub fn horizontal_direction(self) -> Direction {
+        Direction::from_raw(unsafe { hb::hb_script_get_horizontal_direction(self.0) })
     }
 }
 

--- a/src/face.rs
+++ b/src/face.rs
@@ -10,6 +10,12 @@ use crate::blob::Blob;
 use crate::common::{HarfbuzzObject, Owned, Shared, Tag};
 
 /// A wrapper around `hb_face_t`.
+///
+/// An excerpt from harfbuzz documentation:
+/// > Font face is objects represent a single face in a font family. More
+/// > exactly, a font face represents a single face in a binary font file. Font
+/// > faces are typically built from a binary blob and a face index. Font faces
+/// > are used to create fonts.
 #[derive(Debug)]
 pub struct Face<'a> {
     raw: NonNull<hb::hb_face_t>,
@@ -19,9 +25,8 @@ pub struct Face<'a> {
 impl<'a> Face<'a> {
     /// Create a new `Face` from the data.
     ///
-    /// If `data` is not a valid font then this function returns an empty proxy
-    /// value.
-    pub fn new<'b, T: Into<Shared<Blob<'b>>>>(data: T, index: u32) -> Owned<Face<'b>> {
+    /// If `data` is not a valid font then this function returns the empty face.
+    pub fn new<T: Into<Shared<Blob<'a>>>>(data: T, index: u32) -> Owned<Face<'a>> {
         let blob = data.into();
         let hb_face = unsafe { hb::hb_face_create(Shared::into_raw(blob), index) };
         unsafe { Owned::from_raw(hb_face) }

--- a/src/font.rs
+++ b/src/font.rs
@@ -24,6 +24,8 @@ pub(crate) extern "C" fn destroy_box<U>(ptr: *mut c_void) {
 /// A type representing a single font (i.e. a specific combination of typeface
 /// and typesize).
 ///
+/// It safely wraps `hb_font_t`.
+///
 /// # Font Funcs
 ///
 /// A font is one of the most important structures in harfbuzz. It coordinates

--- a/src/rusttype.rs
+++ b/src/rusttype.rs
@@ -96,6 +96,20 @@ impl<'a> FontFuncs for ScaledRusttypeFont<'a> {
 use std::sync::Arc;
 
 /// Creates a new HarfBuzz `Font` object that uses RustType to provide font data.
+/// 
+/// # Examples
+/// 
+/// Create a basic font that uses rusttype font funcs:
+/// ```
+/// use std::fs;
+/// use std::sync::Arc;
+/// 
+/// use harfbuzz_rs::rusttype::create_harfbuzz_rusttype_font;
+/// 
+/// let path = "testfiles/SourceSansVariable-Roman.ttf";
+/// let bytes: Arc<[u8]> = fs::read(path).unwrap().into();
+/// let font = create_harfbuzz_rusttype_font(bytes, 0);
+/// ```
 pub fn create_harfbuzz_rusttype_font(
     bytes: impl Into<Arc<[u8]>>,
     index: u32,


### PR DESCRIPTION
fixes #13 

Create wrapper types for `hb_feature_t`, `hb_segment_properties_t`,  `hb_glyph_position_t`, `hb_glyph_flags_t`, and `hb_script_t` to avoid having to reexport the corresponding harfbuzz-sys types.