### PR TITLE
Fix Memory Leak on Font Creation

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -116,7 +116,7 @@ impl<'a> Font<'a> {
     pub fn new<T: Into<Shared<Face<'a>>>>(face: T) -> Owned<Self> {
         unsafe {
             let face = face.into();
-            let raw_font = hb::hb_font_create(Shared::into_raw(face));
+            let raw_font = hb::hb_font_create(face.as_raw());
             // set default font funcs for a completely new font
             hb::hb_ot_font_set_funcs(raw_font);
             Owned::from_raw(raw_font)


### PR DESCRIPTION
`hb_font_create` internally references the face. Therefore it is incorrect
to call `Shared::into_raw` on the argument.

see https://github.com/servo/rust-harfbuzz/blob/master/harfbuzz-sys/harfbuzz/src/hb-font.cc#L1354

Basically the same as ef01207dcf3e7ae4b6f63fb018fe95b716f993db  cc #19