### PR TITLE
Fix doc(hidden) attr

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -266,7 +266,7 @@ pub unsafe trait HarfbuzzObject: Sized {
     /// changed. Should not be called directly by a library user.
     ///
     /// Use the Owned and Shared abstractions instead.
-    #[doc(hide)]
+    #[doc(hidden)]
     unsafe fn from_raw(val: *const Self::Raw) -> Self;
 
     /// Returns the underlying harfbuzz object pointer.


### PR DESCRIPTION
This is an error with recent nightly rustc:
```
error: unknown `doc` attribute `hide`
   --> /home/dhardy/.cargo/registry/src/github.com-1ecc6299db9ec823/harfbuzz_rs-1.2.0/src/common.rs:269:11
    |
269 |     #[doc(hide)]
    |           ^^^^
```